### PR TITLE
break: update Flux to v0.14 #6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
 
 [compat]
+CUDA = "4"
 Flux = "0.14"
 julia = "1.9"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,12 @@
 name = "TransformersLite"
 uuid = "6579f8b0-5af2-4c97-8a45-e81aa57d569b"
 authors = ["Lior Sinai <sinailior@gmail.com>"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
@@ -13,10 +14,11 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
 
 [compat]
-Flux = "0.13.11"
-julia = "1"
+Flux = "0.14"
+julia = "1.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To run the examples:
 ```bash
 mkdir outputs
 python examples/download_amazon_reviews.py
-julia examples/demo.jl --threads auto
+julia --threads auto --project="." examples\\demo.jl
 ### after training completes
 jupyter notebook
 ```
@@ -96,16 +96,25 @@ However the distributions do have a spread and have significant overlaps of conf
 ## Installation
 
 Download the GitHub repository (it is not registered). Then in the Julia REPL:
-```
+```Julia
 julia> ] # enter package mode
-(@v1.x) pkg> dev path\\to\\TransformersLite
+(@v1.x) pkg> dev path\\to\\TransformersLite.jl
 julia> using Revise # for dynamic editing of code
 julia> using TransformersLite
 ```
 
-Done. 
+To install dependencies, navigate to the TransformersLite directory. Then in the Julia REPL:
+```Julia
+julia> ] # enter package mode
+(@v1.x) pkg> activate .
+(TransformersLite) instantiate 
+```
+Dependencies can also be installed manually in the main Julia environment.
 
-### Dependencies
+The cuDNN library needs to installed separately for CUDA GPU functionality.
+It is added as an artifact via the cuDNN package.
+
+### Non-Julia Dependencies
 
 Other than Julia this requires Python for:
 - HuggingFace datasets package. 

--- a/examples/demo.jl
+++ b/examples/demo.jl
@@ -4,7 +4,7 @@ using Arrow
 using Printf
 using BSON, JSON
 using Flux
-using Flux.CUDA
+using CUDA, cuDNN
 using Flux: DataLoader
 using Unicode
 using Dates
@@ -52,7 +52,9 @@ elseif hyperparameters["tokenizer"] == "none"
     tokenizer = identity
 end
 
-vocab = load_vocab(joinpath(@__DIR__, path_vocab))
+#vocab = load_vocab(joinpath(@__DIR__, path_vocab))
+corpus = String.(df[!, :review_body])
+vocab = select_vocabulary(corpus; min_document_frequency=30)
 indexer = IndexTokenizer(vocab, "[UNK]")
 
 display(tokenizer)
@@ -66,7 +68,7 @@ documents = df[!, :review_body]
 labels = df[!, :stars]
 max_length = 50
 indices_path = joinpath(@__DIR__, "outputs", "indices_" * hyperparameters["tokenizer"] * ".bson")
-@time tokens = map(d->preprocess(d, tokenizer, max_length=max_length), documents)
+@time tokens = map(d->preprocess(d, tokenizer; max_length=max_length), documents)
 @time indices = indexer(tokens)
 
 y_labels = Int.(labels)


### PR DESCRIPTION
This version of Flux uses the new package extensions in v1.9 of Julia. This is used here to load Flux without compiling any of the GPU packages. The complications of CUDA and the corresponding Flux GPU functions are triggered separately with 'using CUDA'