### PR TITLE
Refactor/attention

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TransformersLite"
 uuid = "6579f8b0-5af2-4c97-8a45-e81aa57d569b"
 authors = ["Lior Sinai <sinailior@gmail.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/attention.jl
+++ b/src/attention.jl
@@ -6,17 +6,17 @@ Each array is shaped from `(dm, N, B)` to `(dh, N, nhead, B)` and scaled dot att
 independently along the batch dimensions of `nhead` and `B`.
 The result is then shaped back into a `(dm, N, B)` array.
 """
-function multi_head_scaled_dot_attention(nhead::Int, Q::A1, K::A2, V::A3; kwargs...) where {
-    T, A1 <: AbstractArray{T, 3}, A2 <: AbstractArray{T, 3}, A3 <: AbstractArray{T, 3}}
+function multi_head_scaled_dot_attention(nhead::Int, Q::A3, K::A3, V::A3
+    ; kwargs...) where {T, A3 <: AbstractArray{T, 3}}
     qs = size(Q)
     ks = size(K)
     vs = size(V)
     dm = size(Q, 1)
     dh = div(dm, nhead)
     #size(Q) == (dh*nhead, N, B) => (dh, nhead, N, B) => (dh, N, nhead, B)
-    Q = permutedims(reshape(Q, dh, nhead, qs[2], qs[3]), [1, 3, 2, 4])
-    K = permutedims(reshape(K, dh, nhead, ks[2], ks[3]), [1, 3, 2, 4])
-    V = permutedims(reshape(V, dh, nhead, vs[2], vs[3]), [1, 3, 2, 4])
+    Q = permutedims(reshape(Q, dh, nhead, qs[2], qs[3]), [1, 3, 2, 4]);
+    K = permutedims(reshape(K, dh, nhead, ks[2], ks[3]), [1, 3, 2, 4]);
+    V = permutedims(reshape(V, dh, nhead, vs[2], vs[3]), [1, 3, 2, 4]);
     #size(A) == (dh, N, nhead, B)
     A = scaled_dot_attention(Q, K, V; kwargs...)
     #size(A) == (dh, N, nhead, B) => (dh, nhead, N, B) => (dm, N, B)
@@ -33,27 +33,13 @@ If the inputs are matrices, the output is:
     
     A = 1/sqrt(dh) * value * softmax(transpose(key) * query))
 
-If the inputs are 3D or 4D arrays, the above equation holds for each `A[:, :, i, j]` with inputs indexed at `X[:, :, i, j]` 
+If the inputs are 3D or 4D arrays, the above equation holds for each `A[:, :, k, l]` with inputs indexed at `X[:, :, k, l]` 
 where `X` is the `query`, `key` or `value`.
 """
 function scaled_dot_attention(
-    query::A1, key::A2, value::A3; mask::Union{Nothing, M}=nothing
-    ) where {
-    T, A1 <: AbstractArray{T, 4}, A2 <: AbstractArray{T, 4}, A3 <: AbstractArray{T, 4}, M <: AbstractArray{Bool}}
-    # Batched version. Input is (dh, N, nhead, B)
-    dh = size(query, 1)
-    keyT = permutedims(key, (2, 1, 3, 4)) # (dkv, dh, nhead, B)
-    atten = one(T)/convert(T, sqrt(dh)) .* batched_mul(keyT, query) # (dkv, dq, nhead, B)
-    atten = apply_mask(atten, mask) # (dkv, dq, nhead, B)
-    score = softmax(atten; dims=1)  # (dkv, dq, nhead, B)
-    batched_mul(value, score)       # (dkv, dq, nhead, B)
-end
-
-function scaled_dot_attention(
-    query::A1, key::A2, value::A3
+    query::A3, key::A3, value::A3
     ; mask::Union{Nothing, M}=nothing
-    ) where {
-    T, A1 <: AbstractArray{T, 3}, A2 <: AbstractArray{T, 3}, A3 <: AbstractArray{T, 3}, M <: AbstractArray{Bool}}
+    ) where {T, A3 <: AbstractArray{T, 3}, M <: AbstractArray{Bool}}
     # Input is (dh, N, nhead)
     dh = size(query, 1)
     keyT = permutedims(key, (2, 1, 3)) # (dkv, dh, nhead)
@@ -63,11 +49,18 @@ function scaled_dot_attention(
     batched_mul(value, score)       # (dh, dkv, nhead)*(dkv, dq, nhead) => (dh, dq, nhead)
 end
 
+function scaled_dot_attention(query::A4, key::A4, value::A4; kwargs...) where {T, A4 <: AbstractArray{T, 4}}
+    batch_size = size(query)[3:end]
+    Q, K, V = map(x -> reshape(x, size(x, 1), size(x, 2), :), (query, key, value))
+    A = scaled_dot_attention(Q, K, V; kwargs...)
+    new_A = reshape(A, (size(A, 1), size(A, 2), batch_size...))
+    new_A
+end
+
 function scaled_dot_attention(
-    query::A1, key::A2, value::A3
+    query::A2, key::A2, value::A2
     ; mask::Union{Nothing, M}=nothing
-    ) where {
-    T, A1 <: AbstractMatrix{T}, A2 <: AbstractMatrix{T}, A3 <: AbstractMatrix{T}, M <: AbstractArray{Bool}}
+    ) where {T, A2 <: AbstractMatrix{T}, M <: AbstractArray{Bool}}
     ## Matrix version for a single head. Input is (dh, N)
     dh = size(query, 1) 
     atten = one(T)/convert(T, sqrt(dh)) .* transpose(key) * query # (dkv, dh)*(dh, dq) => (dkv, dq)


### PR DESCRIPTION
Refactoring for the attention.
- Improved efficiency for the attention operation. Reshaping for 4D arrays is done in `scaled_dot_attention` instead of `batched_mul`. This reduces the number of reshapes from 6 (3x2 `batched_mul` calls) to 4.
- Renamed input variable from `dim_model` to `dim_in`.
- Now require the exact same input type for all input arrays. Technically this is a breaking change, albeit a minor one.